### PR TITLE
Vote numbers

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -21,6 +21,7 @@ const NEGATIVE_TRANSLATE = "translate-y-1/2";
 
 export default function Poll() {
   const initialVoteSummary = {
+    //not sure why score and total_votes are stored, since they can be derived from positive_votes and negative_votes.
     score: 0,
     total_votes: 0,
     positive_votes: 0,
@@ -86,19 +87,19 @@ export default function Poll() {
         </div>
 
         <div className={`
-        absolute left-4 font-semibold text-3xl mb-[70px]
+        absolute left-4 font-semibold mb-[80px]
         ease-in-out duration-500 
          ${translate}
         `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
-          <p className='font-semibold text-3xl text-green-500 '>{voteSummary.positive_votes}</p>
+          <p className='font-semibold text-4xl text-green-500 '>{voteSummary.positive_votes}</p>
         </div>
         
         <div className={`
-        absolute left-4 flex flex-col justify-end mt-[70px] 
+        absolute left-4 flex flex-col justify-end mt-[80px] 
         ease-in-out duration-500 
          ${translate}
         `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
-          <p className='font-semibold text-3xl text-red-500 '>{voteSummary.negative_votes}</p>
+          <p className='font-semibold text-4xl text-red-500 '>{voteSummary.negative_votes}</p>
         </div>
 
       </div >

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -87,7 +87,7 @@ export default function Poll() {
         </div>
 
         <div className={`
-        absolute left-4 font-semibold mb-[80px]
+        absolute left-[12px] font-semibold mb-[80px]
         ease-in-out duration-500 
          ${translate}
         `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
@@ -95,7 +95,7 @@ export default function Poll() {
         </div>
         
         <div className={`
-        absolute left-4 flex flex-col justify-end mt-[80px] 
+        absolute left-[12px] flex flex-col justify-end mt-[80px] 
         ease-in-out duration-500 
          ${translate}
         `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -72,6 +72,8 @@ export default function Poll() {
   return (
     <>
       <Script src="https://cdn.tailwindcss.com" />
+      //not sure why styles.container is used instead of tailwind, the following tailwind styles can replace it
+      //min-h-[100vh] p-[0 0.5rem] w-12 flex flex-col justify-center items-center
       <div className={styles.container}>
         <Head>
           <title>Poll Overlay</title>
@@ -82,6 +84,23 @@ export default function Poll() {
         ${opacity} ${translate} ${color}
         `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
         </div>
+
+        <div className={`
+        absolute left-4 font-semibold text-3xl mb-[70px]
+        ease-in-out duration-500 
+         ${translate}
+        `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
+          <p className='font-semibold text-3xl text-green-500 '>{voteSummary.positive_votes}</p>
+        </div>
+        
+        <div className={`
+        absolute left-4 flex flex-col justify-end mt-[70px] 
+        ease-in-out duration-500 
+         ${translate}
+        `} style={{ height: getBarHeight(voteSummary.score, voteSummary.total_votes) }}>
+          <p className='font-semibold text-3xl text-red-500 '>{voteSummary.negative_votes}</p>
+        </div>
+
       </div >
     </>
   );


### PR DESCRIPTION
## Motivation
it can be unclear how many votes have been casted

## Implementation
adds numbers above and below the bar to represent hire and fire votes

## Testing
run on a local version, manually inputted different vote numbers to test it

## Other
2 possible changes: 
1. remove score and total_votes because they can be derived from positive_votes and negative_votes.
2. replace styles.container css with tailwind for better readability.
(i didnt make any changes to either, just added comments)

4-3:
![vote-numbers-1](https://github.com/braddotcoffee/live-polls/assets/116332429/ab9d1f19-7250-4baf-9fdd-31c6878415d8)

4-4:
![vote-numbers-2](https://github.com/braddotcoffee/live-polls/assets/116332429/ae287b05-8e10-4fbb-95c1-db3444b0f84c)

4-5:
![vote-numbers-3](https://github.com/braddotcoffee/live-polls/assets/116332429/e2344eed-a98a-4599-be93-379f91dd1f24)
